### PR TITLE
Fix sortableCheckboxGroupInput/sortableRadioButtons behaviour when inlined

### DIFF
--- a/R/sortableCheckboxGroupInput.R
+++ b/R/sortableCheckboxGroupInput.R
@@ -42,12 +42,14 @@ sortableCheckboxGroupInput <- function(inputId, label, choices = NULL,
 
   shiny_opt <- list(order = list(sortcreate = func, sortupdate = func))
 
+  items_opt <- ifelse(inline, ".checkbox-inline", ".checkbox")
+
   jqui_sortable(
     ui = shiny::checkboxGroupInput(
       inputId, label, choices, selected,
       inline, width, choiceNames,
       choiceValues
     ),
-    options = list(items = ".checkbox", shiny = shiny_opt)
+    options = list(items = items_opt, shiny = shiny_opt)
   )
 }

--- a/R/sortableRadioButtons.R
+++ b/R/sortableRadioButtons.R
@@ -42,11 +42,13 @@ sortableRadioButtons <- function(inputId, label, choices = NULL,
 
   shiny_opt <- list(order = list(sortcreate = func, sortupdate = func))
 
+  items_opt <- ifelse(inline, ".radio-inline", ".radio")
+
   jqui_sortable(
     ui = shiny::radioButtons(
       inputId, label, choices, selected,
       inline, width, choiceNames, choiceValues
     ),
-    options = list(items = ".radio", shiny = shiny_opt)
+    options = list(items = items_opt, shiny = shiny_opt)
   )
 }


### PR DESCRIPTION
Fixes issue #37 so that these are sortable when inline = TRUE.