### PR TITLE
Added Touch Punch to enable mobile/touch support

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -27,8 +27,9 @@ jquiHead <- function() {
     shiny::tags$head(
       shiny::tags$script(src = "shared/jqueryui/jquery-ui.min.js"),
       shiny::tags$link(rel = "stylesheet", href = "shared/jqueryui/jquery-ui.css"),
-      shiny::tags$script(src = "shinyjqui/shinyjqui.js")
+      shiny::tags$script(src = "shinyjqui/shinyjqui.js"),
       # shiny::tags$script(src = 'shinyjqui/shinyjqui.min.js')
+      shiny::tags$script(src = "shinyjqui/jquery.ui.touch-punch.min.js")
     )
   )
 }

--- a/inst/www/jquery.ui.touch-punch.min.js
+++ b/inst/www/jquery.ui.touch-punch.min.js
@@ -1,0 +1,11 @@
+/*!
+ * jQuery UI Touch Punch 0.2.3
+ *
+ * Copyright 2011–2014, Dave Furfero
+ * Dual licensed under the MIT or GPL Version 2 licenses.
+ *
+ * Depends:
+ *  jquery.ui.widget.js
+ *  jquery.ui.mouse.js
+ */
+!function(a){function f(a,b){if(!(a.originalEvent.touches.length>1)){a.preventDefault();var c=a.originalEvent.changedTouches[0],d=document.createEvent("MouseEvents");d.initMouseEvent(b,!0,!0,window,1,c.screenX,c.screenY,c.clientX,c.clientY,!1,!1,!1,!1,0,null),a.target.dispatchEvent(d)}}if(a.support.touch="ontouchend"in document,a.support.touch){var e,b=a.ui.mouse.prototype,c=b._mouseInit,d=b._mouseDestroy;b._touchStart=function(a){var b=this;!e&&b._mouseCapture(a.originalEvent.changedTouches[0])&&(e=!0,b._touchMoved=!1,f(a,"mouseover"),f(a,"mousemove"),f(a,"mousedown"))},b._touchMove=function(a){e&&(this._touchMoved=!0,f(a,"mousemove"))},b._touchEnd=function(a){e&&(f(a,"mouseup"),f(a,"mouseout"),this._touchMoved||f(a,"click"),e=!1)},b._mouseInit=function(){var b=this;b.element.bind({touchstart:a.proxy(b,"_touchStart"),touchmove:a.proxy(b,"_touchMove"),touchend:a.proxy(b,"_touchEnd")}),c.call(b)},b._mouseDestroy=function(){var b=this;b.element.unbind({touchstart:a.proxy(b,"_touchStart"),touchmove:a.proxy(b,"_touchMove"),touchend:a.proxy(b,"_touchEnd")}),d.call(b)}}}(jQuery);


### PR DESCRIPTION
`shinyjqui` previously didn't work on mobile devices as the base Jquery UI didn't support touch-based events. By incorporating [Touch Punch](http://touchpunch.furf.com/) we can simulate events to map touch events to their mouse event analogs.